### PR TITLE
Change 'symbolic link file' suggestion to 'copy file'

### DIFF
--- a/pre-commit.hook
+++ b/pre-commit.hook
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 ####
 #### This is a suggested pre-commit hook to be used with pep8.
-#### Make a symlink to this file as .git/hooks/pre-commit
+#### To use: copy this file to .git/hooks/pre-commit
 ####
 #### Credits go to Kevin McConnell
 #### http://tech.myemma.com/python-pep8-git-hooks/


### PR DESCRIPTION
On purpose it's impossible to include .git/\* files to the repository because of security issues.
Symbolic linking a tracked file, in the .git/\* direcotry, will bypass this inconvenience but will introduce the security issues mentioned before.

It's not wise to suggest such a thing... my bad.
